### PR TITLE
decomission: allow resolving CR clusters in namespaces outside of ope…

### DIFF
--- a/pkg/actor/decommission.go
+++ b/pkg/actor/decommission.go
@@ -82,8 +82,9 @@ func (d decommission) Act(ctx context.Context, cluster *resource.Cluster, log lo
 	// If we are running inside of k8s we will not find this file.
 	runningInsideK8s := inK8s("/var/run/secrets/kubernetes.io/serviceaccount/token")
 
-	serviceName := cluster.PublicServiceName()
+	var serviceName string
 	if runningInsideK8s {
+		serviceName = fmt.Sprintf("%s.%s", cluster.PublicServiceName(), cluster.Namespace())
 		log.V(DEBUGLEVEL).Info("operator is running inside of kubernetes, connecting to service for db connection")
 	} else {
 		serviceName = fmt.Sprintf("%s-0.%s.%s", cluster.Name(), cluster.Name(), cluster.Namespace())


### PR DESCRIPTION
Cluster decomission: allow resolving CRDB clusters in k8s namespaces outside of the operator namespace by qualifying the hostname with the k8s namespace.